### PR TITLE
Fixed typo "boostrap_proto" to "bootstrap_proto".

### DIFF
--- a/mapping.txt
+++ b/mapping.txt
@@ -1,1 +1,1 @@
-boostrap_proto : bootstrap_protocol
+bootstrap_proto : bootstrap_protocol


### PR DESCRIPTION
this typo can create issue while testing programs.