### PR TITLE
Fix typo in mapping.txt file for json key.

### DIFF
--- a/mapping.txt
+++ b/mapping.txt
@@ -1,1 +1,1 @@
-boostrap_proto : bootstrap_protocol
+bootstrap_proto : bootstrap_protocol


### PR DESCRIPTION
   There is a typo in mapping.txt for the json key
   'boostrap_proto'. I don't know if it is intentional
   but there is no such key by that name and it should
   be corrected to 'bootstrap_proto' which is a valid
   json key in the respective json file.